### PR TITLE
Use the indicators-values table on cartoDB to get the list of availab…

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -11,10 +11,15 @@ class Country
     end
 
     def find_all
-      url = base_path
+      sql = <<-SQL
+        SELECT DISTINCT iso, admin0_name AS name, true as enabled
+        FROM indicators_values
+        ORDER BY name
+      SQL
+      url = "#{ENV['CDB_API_HOST']}?q=#{sql}"
       timeouts do
         items_caching do
-          get(url)['countries']
+          get(url)['rows']
         end
       end
     end

--- a/spec/acceptance/api/v1/countries_spec.rb
+++ b/spec/acceptance/api/v1/countries_spec.rb
@@ -10,9 +10,9 @@ resource 'Countries' do
       expect(status).to eq(200)
       countries = JSON.parse(response_body)['countries']
 
-      expect(countries.length).to eq(167)
-      expect(countries[6]['name']).to eq('Australia')
-      expect(countries[6]['iso']).to eq('AUS')
+      expect(countries.length).to eq(105)
+      expect(countries[6]['name']).to eq('Barbados')
+      expect(countries[6]['iso']).to eq('BRB')
       expect(countries[6]['enabled']).to eq(true)
     end
   end

--- a/spec/controllers/countries_controller_spec.rb
+++ b/spec/controllers/countries_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CountriesController, type: :controller do
       get :index
       expect(response).to be_success
       expect(response).to have_http_status(200)
-      expect(response.body).to match 'Afghanistan'
+      expect(response.body).to match 'Angola'
     end
 
     it "GET cached countries page", type: :feature do

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Country, type: :model do
 
     it "Find all countries" do
       countries = Country.find_all
-      expect(countries[0]['name']).to eq 'Afghanistan'
+      expect(countries[0]['name']).to eq 'Angola'
     end
 
   end


### PR DESCRIPTION
This PR uses the indicators_values table to get the list of available countries for this project.
In the future it would be recommended to add "pantropical?" boolean to the main countries table and adding filtering on it to the gfw-api. But as a temporary solution this should work.