### PR TITLE
Widget layout tweaks.

### DIFF
--- a/app/assets/javascripts/widgets/templates/tab.handlebars
+++ b/app/assets/javascripts/widgets/templates/tab.handlebars
@@ -22,26 +22,25 @@
       canopy density</span>
     </div>
   {{/if}}
+  {{#if this.range}}
+  <div class="sub-options">
+      <div class="average">
+        <span>Average:</span>
+        <select class="selector date-selector blue start-date" data-direction="1" data-compare=".end-date" name="start-date">
+          {{#each this.range}}
+            <option value="{{this}}">{{this}}</option>
+          {{/each}}
+        </select>
+        <span>to</span>
+        <select class="selector date-selector blue end-date" data-direction="0" data-compare=".start-date" name="end-date">
+          {{#each this.range}}
+            <option value="{{this}}">{{this}}</option>
+          {{/each}}
+        </select>
+        <span class="tab-average"></span>
+      </div>
+  </div>
+  {{/if}}
 </div>
 
 <div class="tab-graph"></div>
-
-{{#if this.range}}
-<div class="sub-options">
-    <div class="average">
-      <span>Average:</span>
-      <select class="selector date-selector blue start-date" data-direction="1" data-compare=".end-date" name="start-date">
-        {{#each this.range}}
-          <option value="{{this}}">{{this}}</option>
-        {{/each}}
-      </select>
-      <span>to</span>
-      <select class="selector date-selector blue end-date" data-direction="0" data-compare=".start-date" name="end-date">
-        {{#each this.range}}
-          <option value="{{this}}">{{this}}</option>
-        {{/each}}
-      </select>
-      <span class="tab-average"></span>
-    </div>
-</div>
-{{/if}}

--- a/app/assets/stylesheets/modules/countries/_grid.scss
+++ b/app/assets/stylesheets/modules/countries/_grid.scss
@@ -1,7 +1,9 @@
 .gridgraphs {
+
   > .gridgraphs-header {
     overflow: hidden;
     margin: 60px 0 0;
+
     > .btn  {
       float: right;
     }
@@ -12,15 +14,36 @@
     flex-wrap: wrap;
     margin: 25px 0;
     padding: 0;
+
     > .gridgraphs-widget {
       width: 47.5%;
+      border-bottom: 1px solid #e5e5e5;
+      padding-bottom: 80px;
+      margin-bottom: 60px;
+  
+      &:nth-child(2n +1) {
+        position: relative;
+
+        &:after {
+          content: "";
+          display: block;
+          position: absolute;
+          bottom: -1px;
+          right: -25%;
+          width: 25%;
+          height: 1px;
+          background-color: #e5e5e5;
+        }
+      }
     }
   }
 
   &.-areas,
   &.-subnational {
+
     > .gridgraphs-content {
       transform: translate(0, -1.05%);
+
       > .box > .title {
         font-size: 32px;
         color: $dark;

--- a/app/assets/stylesheets/modules/widgets/_tabs.scss
+++ b/app/assets/stylesheets/modules/widgets/_tabs.scss
@@ -16,10 +16,9 @@
 
   // SUB OPTIONS
   .sub-options {
-    margin-top: 20px;
     padding-top: 20px;
     font-size: 12px;
-    border-top: 1px solid #e5e5e5;
+    float: right;
   }
 
 

--- a/app/assets/stylesheets/modules/widgets/_tabs.scss
+++ b/app/assets/stylesheets/modules/widgets/_tabs.scss
@@ -16,6 +16,7 @@
 
   // SUB OPTIONS
   .sub-options {
+    margin-top: 20px;
     padding-top: 20px;
     font-size: 12px;
     border-top: 1px solid #e5e5e5;


### PR DESCRIPTION
- [COUNTRY PROFILES] separate each widget obviously (for example put a thin blue line around each widget to indicate where it starts and ends).

-[COUNTRY PROFILES] Move the year selection and average to the top of the widget (underneath the canopy selection).

IMHO, the second task is not a good idea... but client said so...