### PR TITLE
Feature/dashboard custom

### DIFF
--- a/app/assets/javascripts/compare/templates/compareModal.handlebars
+++ b/app/assets/javascripts/compare/templates/compareModal.handlebars
@@ -52,20 +52,24 @@
         </div>
         {{#if country2}}
           <div class="m-field">
-            <h3>Juristiction (optional)</h3>
-            <ul class="m-field-list compare-jurisdiction">
-              {{#each country2.jurisdictions}}
-                <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
-              {{/each}}
-            </ul>
-          </div>
-          <div class="m-field">
             <h3>Area of interest (optional)</h3>
             <ul class="m-field-list compare-area">
               {{#each country2.areas}}
                 <li class="m-field-list-radio m-field-list-radio-area" data-id="{{id}}">{{this.name}}</li>
               {{/each}}
             </ul>
+          </div>
+          <div class="m-field">
+            <h3>Jurisdiction (optional)</h3>
+            {{#if country2.jurisdictions}}
+              <ul class="m-field-list compare-jurisdiction">
+                {{#each country2.jurisdictions}}
+                  <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
+                {{/each}}
+              </ul>
+            {{else}}
+              <p>No jurisdictions for this country</p>
+            {{/if}}
           </div>
         {{else}}
           <div class="m-alert">Choose a <span>country</span> to compare</div>

--- a/app/assets/javascripts/compare/templates/compareModal.handlebars
+++ b/app/assets/javascripts/compare/templates/compareModal.handlebars
@@ -21,20 +21,24 @@
         </div>
         {{#if country1}}
           <div class="m-field">
-            <h3>Juristiction (optional)</h3>
-            <ul class="m-field-list compare-jurisdiction">
-              {{#each country1.jurisdictions}}
-                <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
-              {{/each}}
-            </ul>
-          </div>
-          <div class="m-field">
             <h3>Area of interest (optional)</h3>
             <ul class="m-field-list compare-area">
               {{#each country1.areas}}
                 <li class="m-field-list-radio m-field-list-radio-area" data-id="{{id}}">{{this.name}}</li>
               {{/each}}
             </ul>
+          </div>
+          <div class="m-field">
+            <h3>Jurisdiction (optional)</h3>
+            {{#if country1.jurisdictions}}
+            <ul class="m-field-list compare-jurisdiction">
+              {{#each country1.jurisdictions}}
+                <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
+              {{/each}}
+            </ul>
+            {{else}}
+            <p>No jurisdiction for this country</p>
+            {{/if}}
           </div>
         {{else}}
           <div class="m-alert">Choose a <span>country</span> to compare</div>
@@ -61,14 +65,14 @@
           </div>
           <div class="m-field">
             <h3>Jurisdiction (optional)</h3>
-            {{#if country2.jurisdictions}}
-              <ul class="m-field-list compare-jurisdiction">
-                {{#each country2.jurisdictions}}
-                  <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
-                {{/each}}
-              </ul>
+            {{#if country1.jurisdictions}}
+            <ul class="m-field-list compare-jurisdiction">
+              {{#each country2.jurisdictions}}
+                <li class="m-field-list-radio m-field-list-radio-jurisdiction" data-id="{{id}}">{{this.name}}</li>
+              {{/each}}
+            </ul>
             {{else}}
-              <p>No jurisdictions for this country</p>
+            <p>No jurisdiction for this country</p>
             {{/if}}
           </div>
         {{else}}

--- a/app/assets/javascripts/compare/views/index/CompareModalView.js
+++ b/app/assets/javascripts/compare/views/index/CompareModalView.js
@@ -56,6 +56,9 @@ define([
       (country1) ? country1.areas = this.areas : null;
       (country2) ? country2.areas = this.areas : null;
       // ***** //
+
+      // console.log(country1);
+      // console.log(country2);
       return {
         countries: this.status.get('countries'),
         country1: country1,


### PR DESCRIPTION
[COUNTRY COMPARISONS] When you select indicators, areas of interest is too far down. Can we make the pop up box a little larger, and put the jurisdiction and areas of interest options next to each other, rather than one on top of the other?

Changed options order. Above Areas of interest, jurisdictions below. 