### PR TITLE
Feature/widget fao note

### DIFF
--- a/app/assets/javascripts/widgets/indicators/multiline/MultiLineChartIndicator.js
+++ b/app/assets/javascripts/widgets/indicators/multiline/MultiLineChartIndicator.js
@@ -94,8 +94,8 @@ define([
             rangeY = this.getRangeY(data);
       }
 
+      // To show message when this widgets have negative vaules.
       var widgetId = _.pluck(this.model.get('indicators'), 'id').join('');
-      console.log(widgetId)
       if ( widgetId == 15 || widgetId == 16 ) {
         this._checkNegativeValues(data);
       }
@@ -129,7 +129,6 @@ define([
       for(var key in data[0]) {
         var value = data[0][key].value;
         if ( value < 0 ) {
-          console.log(this);
           this.$('.fao-note').removeClass('is-hidden');
           break
         }

--- a/app/assets/javascripts/widgets/indicators/multiline/MultiLineChartIndicator.js
+++ b/app/assets/javascripts/widgets/indicators/multiline/MultiLineChartIndicator.js
@@ -93,6 +93,13 @@ define([
             rangeX = this.getRangeX(data),
             rangeY = this.getRangeY(data);
       }
+
+      var widgetId = _.pluck(this.model.get('indicators'), 'id').join('');
+      console.log(widgetId)
+      if ( widgetId == 15 || widgetId == 16 ) {
+        this._checkNegativeValues(data);
+      }
+
       if (this.getDataLength(data)) {
         // Initialize Line Chart
         this.chart = new MultiLineChart({
@@ -115,6 +122,17 @@ define([
         this.chart.render();
       } else {
         this.$el.html(this.noDataTemplate({ classname: 'line'}));
+      }
+    },
+
+    _checkNegativeValues: function(data) {
+      for(var key in data[0]) {
+        var value = data[0][key].value;
+        if ( value < 0 ) {
+          console.log(this);
+          this.$('.fao-note').removeClass('is-hidden');
+          break
+        }
       }
     },
 

--- a/app/assets/javascripts/widgets/templates/indicators/line/linechart.handlebars
+++ b/app/assets/javascripts/widgets/templates/indicators/line/linechart.handlebars
@@ -1,2 +1,10 @@
 <div class="linechart-graph"></div>
 <div class="linechart-legend"></div>
+
+<div class="fao-note is-hidden">
+  <p>
+    * According to FAO data, this country showed a net gain in forest area over this time period. Net and gross forest change are not the same thing.
+    <a href="">See more</a>
+  </p>
+</div>
+

--- a/app/assets/javascripts/widgets/templates/tab.handlebars
+++ b/app/assets/javascripts/widgets/templates/tab.handlebars
@@ -53,3 +53,4 @@
     <div class="tab-average"></div>
 </div>
 {{/if}}
+

--- a/app/assets/stylesheets/modules/widgets/_tabs.scss
+++ b/app/assets/stylesheets/modules/widgets/_tabs.scss
@@ -88,6 +88,15 @@
       min-height: 120px;
     }
 
+    .fao-note {
+      font-size: 12px;
+      margin: 1em 0;
+
+      a, p {
+        display: inline-block;
+      }
+    }
+
     .tab-graph--no-data {
 
       div {

--- a/app/assets/stylesheets/modules/widgets/charts/_line-graph.scss
+++ b/app/assets/stylesheets/modules/widgets/charts/_line-graph.scss
@@ -420,18 +420,22 @@
 }
 
 .linechart-legend {
-  margin: 0 0 0 30px;
+  margin: 0;
+
   > ul {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
+
     > li{
       position: relative;
       padding: 3px 0 0 22px;
       margin: 0 0 0 20px;
+
       &:first-child {
-        margin: 0;
+        margin-left: 30px;
       }
+
       > span {
         display: block;
         position: absolute;


### PR DESCRIPTION
Where FAO deforestation rate and percentage (indicator 15-16) in table is negative, display text in graph "According to FAO data, this country showed a net gain in forest area over this time period. Net and gross forest change are not the same thing." Then a see more button that links to the info bubble.

The bubble thing is not done yet. 