### PR TITLE
Fix timeline visualization

### DIFF
--- a/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
+++ b/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
@@ -70,6 +70,7 @@ define([
        for(var j = 0 |0; j < h; ++j) {
           var pixelPos  = ((j * w + i) * components) |0,
               intensity = imgdata[pixelPos+1] |0;
+          imgdata[pixelPos + 3] = 0 |0;
           if (intensity > 0) {
             var intensity_scaled = myscale(intensity) |0,
                 yearLoss = 2001 + imgdata[pixelPos] |0;
@@ -80,9 +81,7 @@ define([
               imgdata[pixelPos + 2] = c[bucket + 2];
               imgdata[pixelPos + 3] = 255 | 0;
             }
-          } else {
-            imgdata[pixelPos + 3] = 0 |0;
-          }
+          } 
         }
        }
     },


### PR DESCRIPTION
This commit https://github.com/Vizzuality/gfw-climate/commit/5ecd71c2be8d7c80fbf7d2ee1ac17c62b7aaaf69#diff-ba54c628a46b4c93680f3b92b62363d4 broke the visualization, and the undesired blue areas are showing up again. the alpha channel should be set to 0 in a different if/else block (please check the visualization is working after changing the code in the future)

Applying a quick fix, should check this more carefully when we have time.

Please chack locally before deploying, I haven't done so as I don't have the project installed