### PR TITLE
Analytics cookie domain

### DIFF
--- a/app/views/shared/_js_footer.html.slim
+++ b/app/views/shared/_js_footer.html.slim
@@ -8,7 +8,7 @@ javascript:
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', "#{ENV["ANALYTICS_PROPERTY_ID"]}", 'globalforestwatch.org');
+  ga('create', "#{ENV["ANALYTICS_PROPERTY_ID"]}", document.location.hostname);
   ga('require', 'displayfeatures');
   ga('send', 'pageview');
   ga('push','_trackPageview');


### PR DESCRIPTION
We are now going to use the document.location.hostname as they recommend on the documentation for the cookieDomain param. Here you have some info related to this, why we are going to do this.
- https://www.pivotaltracker.com/story/show/117420795

- https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#configuring_cookie_field_settings