### PR TITLE
Show transifex only in local and staging

### DIFF
--- a/app/views/shared/_transifex_setup.html.slim
+++ b/app/views/shared/_transifex_setup.html.slim
@@ -1,9 +1,10 @@
 javascript:
-  if(location.hostname.indexOf('globalforestwatch.org') !== -1)
-    window.liveSettings= { api_key:"35ae26e6686249dea297972fc1978922",
-      picker: '#ma-div-temp-for-collection',
+  if(location.hostname.indexOf('globalforestwatch.org') === -1) {
+    window.liveSettings = { 
+    	api_key:"35ae26e6686249dea297972fc1978922",
+      picker: '#transifexTranslateElement',
       detectlang: false,
       autocollect: true,
-      staging: false};
-
-script type="text/javascript" src="//cdn.transifex.com/live.js"
+      staging: false
+    };
+  }


### PR DESCRIPTION
- We were always setting the liveSettings, but it shouldn't be at production. That's why I have changed the condition. 
- Another fix was the element were we should render the transifex element `#transifexTranslateElement`
- I've also removed the transifex script, because the app-bar loads it