### PR TITLE
Fix: Legend - Restored static legends.

### DIFF
--- a/app/assets/javascripts/map/views/LegendView.js
+++ b/app/assets/javascripts/map/views/LegendView.js
@@ -229,6 +229,11 @@ define([
             units: layerData.units,
             unit: layerData.unit
           });
+        } else if (this.detailsTemplates[layer.slug]) {
+          layer.detailsTpl = this.detailsTemplates[layer.slug]({
+            threshold: options.threshold || 30,
+            layerTitle: layer.title
+          });
         }
         if (layer.iso) {
           var countries = amplify.store('countries');


### PR DESCRIPTION
- When adding the dynamic selector for Aboveground Live Woody Biomass density the static legends were not being included.