### PR TITLE
Feature: buckets for carbon stocks + performance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,5 +322,12 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
+<<<<<<< Updated upstream
    1.13.4
+=======
+   1.13.6
+>>>>>>> Stashed changes

--- a/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
+++ b/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
@@ -65,32 +65,39 @@ define([
          .exponent(exp)
          .domain([0,256])
          .range([0,256]);
-      var c = [255, 31,  38, // first bucket R G B
+
+      var buckets = [255, 31,  38, // first bucket R G B
                210, 31,  38,
                210, 31,  38,
                241, 152, 19,
                255, 208, 11]; // last bucket
-      var countBuckets = c.length / 3 |0; //3: three bands
+      var countBuckets = buckets.length / 3 |0; //3: three bands
+
       for(var i = 0 |0; i < w; ++i) {
        for(var j = 0 |0; j < h; ++j) {
-          var pixelPos  = ((j * w + i) * components) |0,
-          // drop year=0 values from loop opcacity = 0 and exit
-              intensity = imgdata[pixelPos + 1] |0,
-              bla = imgdata[pixelPos + 2] |0;
-              imgdata[pixelPos + 3] = 0 |0;
-          if (bla >= this.minrange && bla <= this.maxrange) {
-            var intensity_scaled = myscale(intensity) |0,
-                yearLoss = 2000 + imgdata[pixelPos] |0;
-            if (yearLoss >= yearStart && yearLoss <= yearEnd) {
-              var bucket = (~~(countBuckets * intensity_scaled / 256) * 3);
-              imgdata[pixelPos] = c[bucket]; //R 0-255
-              imgdata[pixelPos + 1] = c[bucket + 1]; //G 0-255
-              imgdata[pixelPos + 2] = c[bucket + 2]; //B 0-255
-              imgdata[pixelPos + 3] = intensity_scaled | 0; //alpha channel 0-255
+          var pixelPos  = ((j * w + i) * components) |0;
+          // exit if year = 0 to reduce memory use
+          if ( imgdata[pixelPos] === 0 ) {
+            imgdata[pixelPos + 3] = 0 |0; //alpha channel 0-255
+          } else {
+            // get values from data
+            var intensity = imgdata[pixelPos + 1] |0,
+                intensity = myscale(intensity) |0;
+                imgdata[pixelPos + 3] = 0 |0;
+            // filter range from dashboard
+            if (intensity >= this.minrange && intensity <= this.maxrange) {
+                  var yearLoss = 2000 + imgdata[pixelPos] |0;
+              if (yearLoss >= yearStart && yearLoss <= yearEnd) {
+                var bucket = (~~(countBuckets * intensity / 256) * 3);
+                imgdata[pixelPos] = buckets[bucket]; //R 0-255
+                imgdata[pixelPos + 1] = buckets[bucket + 1]; //G 0-255
+                imgdata[pixelPos + 2] = buckets[bucket + 2]; //B 0-255
+                imgdata[pixelPos + 3] = intensity | 0; //alpha channel 0-255
+              }
             }
           }
         }
-       }
+      }
     },
 
     /**

--- a/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
+++ b/app/assets/javascripts/map/views/layers/BiomassLossLayer.js
@@ -74,9 +74,11 @@ define([
       for(var i = 0 |0; i < w; ++i) {
        for(var j = 0 |0; j < h; ++j) {
           var pixelPos  = ((j * w + i) * components) |0,
-              intensity = imgdata[pixelPos+1] |0;
+          // drop year=0 values from loop opcacity = 0 and exit
+              intensity = imgdata[pixelPos + 1] |0,
+              bla = imgdata[pixelPos + 2] |0;
               imgdata[pixelPos + 3] = 0 |0;
-          if (intensity >= this.minrange && intensity <= this.maxrange) {
+          if (bla >= this.minrange && bla <= this.maxrange) {
             var intensity_scaled = myscale(intensity) |0,
                 yearLoss = 2000 + imgdata[pixelPos] |0;
             if (yearLoss >= yearStart && yearLoss <= yearEnd) {

--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -61,9 +61,10 @@ define([
           // get values from imgdata
           carbonStock = imgdata[pixelPos + 2] | 0,
           uncertainty = imgdata[pixelPos + 3] | 0;
-
           // scale values
           uncertainty = uncertainty > 100 ? 100 : (uncertainty < 0 ? 0 : uncertainty);
+          // init set alpha to 0
+          imgdata[pixelPos + 3] = 0;
 
           if(carbonStock >= this.minrange && carbonStock <= this.maxrange) {
             if(this.uncertainty === 0) {
@@ -74,18 +75,14 @@ define([
               // max uncertainty sum the uncertainty value
               carbonStock = carbonStock + (uncertainty * carbonStock / 100);
             }
-
             // Calc bucket from carbonStock as a factor of bucket number
             var bucket = (carbonStock * countBuckets) / this.options.maxrange;
             // Find floor to give bucket index
             var bucketIndex = ~~bucket;
-
             imgdata[pixelPos] = buckets[bucketIndex * 3];
             imgdata[pixelPos + 1] = buckets[bucketIndex * 3 + 1];
             imgdata[pixelPos + 2] = buckets[bucketIndex * 3 + 2];
             imgdata[pixelPos + 3] = carbonStock;
-          } else {
-            imgdata[pixelPos + 3] = 0;
           }
         }
       }

--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -59,8 +59,8 @@ define([
 
           // get values
           // var carbonStock = imgdata[pixelPos + 2];
-          var intensity = imgdata[pixelPos + 2];
-          var uncertainty = imgdata[pixelPos + 3];
+          var intensity = imgdata[pixelPos + 2] | 0;
+          var uncertainty = imgdata[pixelPos + 3] | 0;
 
           // scale values
           uncertainty = uncertainty > 100 ? 100 : (uncertainty < 0 ? 0 : uncertainty);

--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -49,41 +49,41 @@ define([
                174, 176, 49,
                173, 209, 81,
                179, 249, 122]; // last bucket
-      var countBuckets = buckets.length / 3;
+      // cache bucket length
+      var countBuckets = buckets.length / 3 |0;
 
       for(var i = 0 |0; i < w; ++i) {
         for(var j = 0 |0; j < h; ++j) {
 
           // find pixel position
-          var pixelPos = ((j * w + i) * components) | 0;
+          var pixelPos = ((j * w + i) * components) | 0,
 
-          // get values
-          // var carbonStock = imgdata[pixelPos + 2];
-          var intensity = imgdata[pixelPos + 2] | 0;
-          var uncertainty = imgdata[pixelPos + 3] | 0;
+          // get values from imgdata
+          carbonStock = imgdata[pixelPos + 2] | 0,
+          uncertainty = imgdata[pixelPos + 3] | 0;
 
           // scale values
           uncertainty = uncertainty > 100 ? 100 : (uncertainty < 0 ? 0 : uncertainty);
 
-          if(intensity >= this.minrange && intensity <= this.maxrange) {
+          if(carbonStock >= this.minrange && carbonStock <= this.maxrange) {
             if(this.uncertainty === 0) {
               // min uncertainty subtract the percentage of uncertainty
-              intensity = intensity - (uncertainty * intensity / 100);
-              intensity = intensity < 1 ? 1 : intensity;
+              carbonStock = carbonStock - (uncertainty * carbonStock / 100);
+              carbonStock = carbonStock < 1 ? 1 : carbonStock;
             } else if(this.uncertainty === 254) {
               // max uncertainty sum the uncertainty value
-              intensity = intensity + (uncertainty * intensity / 100);
+              carbonStock = carbonStock + (uncertainty * carbonStock / 100);
             }
 
-            // Calc bucket from intensity as a factor of bucket no
-            var bucket = (intensity * countBuckets) / this.options.maxrange;
+            // Calc bucket from carbonStock as a factor of bucket number
+            var bucket = (carbonStock * countBuckets) / this.options.maxrange;
             // Find floor to give bucket index
             var bucketIndex = ~~bucket;
 
             imgdata[pixelPos] = buckets[bucketIndex * 3];
             imgdata[pixelPos + 1] = buckets[bucketIndex * 3 + 1];
             imgdata[pixelPos + 2] = buckets[bucketIndex * 3 + 2];
-            imgdata[pixelPos + 3] = intensity;
+            imgdata[pixelPos + 3] = carbonStock;
           } else {
             imgdata[pixelPos + 3] = 0;
           }

--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -52,8 +52,8 @@ define([
           var uncer = imgdata[pixelPos + 3];
           uncer = uncer > 100 ? 100 : (uncer < 0 ? 0 : uncer);
 
-
           if(intensity >= this.minrange && intensity <= this.maxrange) {
+            // debugger
             if(this.uncertainty === 0) {
               // min uncertainty subtract the percentage of uncertainty
               intensity = intensity - (uncer*intensity/100);
@@ -62,10 +62,24 @@ define([
               // max uncertainty sum the uncertainty value
               intensity = intensity + (uncer*intensity/100);
             }
-            imgdata[pixelPos] = 255-intensity;
-            imgdata[pixelPos + 1] = 128;
-            imgdata[pixelPos + 2] = 0;
-            imgdata[pixelPos + 3] = intensity;
+
+            // create buckets
+            var c = [39, 11,  3, // first bucket R G B
+                     83, 44,  8,
+                     130, 104,  26,
+                     174, 176, 49,
+                     173, 209, 81,
+                     179, 249, 122]; // last bucket
+
+            // Calc bucket from intensity as a factor of 6 (returns decimal)
+            var bucket = (intensity + 3) / 43;
+            // Find floor to give bucket index
+            var bucketIndex = Math.floor(bucket);
+
+            imgdata[pixelPos] = c[bucketIndex * 3];
+            imgdata[pixelPos + 1] = c[bucketIndex * 3 + 1];
+            imgdata[pixelPos + 2] = c[bucketIndex * 3 + 2];
+            imgdata[pixelPos + 3] = 255;
           } else {
             imgdata[pixelPos + 3] = 0;
           }

--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -42,44 +42,48 @@ define([
           w = w |0,
           j = j |0;
 
+      // create buckets
+      var buckets = [39, 11,  3, // first bucket R G B
+               83, 44,  8,
+               130, 104,  26,
+               174, 176, 49,
+               173, 209, 81,
+               179, 249, 122]; // last bucket
+      var countBuckets = buckets.length / 3;
+
       for(var i = 0 |0; i < w; ++i) {
         for(var j = 0 |0; j < h; ++j) {
-          var pixelPos  = ((j * w + i) * components) |0,
-          // intensity = imgdata[pixelPos+2]-(imgdata[pixelPos+3]*imgdata[pixelPos+2]/100) |0;
-          intensity = imgdata[pixelPos+2];
-          //if (intensity>255) intensity=255;
-          //if (intensity<0) intensity=0;
-          var uncer = imgdata[pixelPos + 3];
-          uncer = uncer > 100 ? 100 : (uncer < 0 ? 0 : uncer);
+
+          // find pixel position
+          var pixelPos = ((j * w + i) * components) | 0;
+
+          // get values
+          // var carbonStock = imgdata[pixelPos + 2];
+          var intensity = imgdata[pixelPos + 2];
+          var uncertainty = imgdata[pixelPos + 3];
+
+          // scale values
+          uncertainty = uncertainty > 100 ? 100 : (uncertainty < 0 ? 0 : uncertainty);
 
           if(intensity >= this.minrange && intensity <= this.maxrange) {
-            // debugger
             if(this.uncertainty === 0) {
               // min uncertainty subtract the percentage of uncertainty
-              intensity = intensity - (uncer*intensity/100);
+              intensity = intensity - (uncertainty * intensity / 100);
               intensity = intensity < 1 ? 1 : intensity;
             } else if(this.uncertainty === 254) {
               // max uncertainty sum the uncertainty value
-              intensity = intensity + (uncer*intensity/100);
+              intensity = intensity + (uncertainty * intensity / 100);
             }
 
-            // create buckets
-            var c = [39, 11,  3, // first bucket R G B
-                     83, 44,  8,
-                     130, 104,  26,
-                     174, 176, 49,
-                     173, 209, 81,
-                     179, 249, 122]; // last bucket
-
-            // Calc bucket from intensity as a factor of 6 (returns decimal)
-            var bucket = (intensity + 3) / 43;
+            // Calc bucket from intensity as a factor of bucket no
+            var bucket = (intensity * countBuckets) / this.options.maxrange;
             // Find floor to give bucket index
-            var bucketIndex = Math.floor(bucket);
+            var bucketIndex = ~~bucket;
 
-            imgdata[pixelPos] = c[bucketIndex * 3];
-            imgdata[pixelPos + 1] = c[bucketIndex * 3 + 1];
-            imgdata[pixelPos + 2] = c[bucketIndex * 3 + 2];
-            imgdata[pixelPos + 3] = 255;
+            imgdata[pixelPos] = buckets[bucketIndex * 3];
+            imgdata[pixelPos + 1] = buckets[bucketIndex * 3 + 1];
+            imgdata[pixelPos + 2] = buckets[bucketIndex * 3 + 2];
+            imgdata[pixelPos + 3] = intensity;
           } else {
             imgdata[pixelPos + 3] = 0;
           }


### PR DESCRIPTION
Changing the Carbon Stocks layer (biomass density) to buckets:
- set buckets and scale carbon stock value (B) against them
- sync max/min range filters with legend
- update order of variable calls for reduced assignment -> performance improvements

Update Biomass Loss layer:
- reduce unnecessary variable calls with stricter filtering to reduce unwanted RGBA assignments
- change order of conditional statements to reduce loop count

Additional: separate variable names and add comments for clearer inspection in the future.