### PR TITLE
Fix: Avoid showing the names without provinces and number parsing

### DIFF
--- a/app/assets/javascripts/countries/templates/countryReport.handlebars
+++ b/app/assets/javascripts/countries/templates/countryReport.handlebars
@@ -67,10 +67,12 @@
         <div class="row">
           <div class="col -wide-text">
             <p>Emissions from deforestation in {{country}} in {{monitorStart}}-{{monitorEnd}} ({{totalMonitoring}} Mt CO2 yr<sup>-1</sup>) were {{increaseDisplay}}% {{#if hasIncreased}}higher{{else}}lower{{/if}} than the historical average of {{totalReference}} Mt CO2 yr<sup>-1</sup> ({{referenceStart}} - {{referenceEnd}}). This is {{#if hasIncreased}}bad{{else}}good{{/if}} news for forests and climate change in {{country}}!
-            {{#if hasIncreased}}
-              The largest proportion of this overall increase occurred within {{co2EmissionsByProvinces.0.province}} and {{co2EmissionsByProvinces.1.province}}.
-            {{else}}
-              Despite this overall decrease, emissions increased most in {{co2EmissionsByProvinces.0.province}} and {{co2EmissionsByProvinces.1.province}}.
+            {{#if hasProvinces}}
+              {{#if hasIncreased}}
+                The largest proportion of this overall increase occurred within {{co2EmissionsByProvinces.0.province}} and {{co2EmissionsByProvinces.1.province}}.
+              {{else}}
+                Despite this overall decrease, emissions increased most in {{co2EmissionsByProvinces.0.province}} and {{co2EmissionsByProvinces.1.province}}.
+              {{/if}}
             {{/if}}
           </div>
         </div>

--- a/app/assets/javascripts/countries/views/CountryReportView.js
+++ b/app/assets/javascripts/countries/views/CountryReportView.js
@@ -5,6 +5,7 @@ define([
   'moment',
   'underscore',
   '_string',
+  'helpers/NumbersHelper',
   'countries/services/ReportService',
   'countries/views/report/SummaryChartView',
   'countries/views/report/HistoricalTrendChartView',
@@ -19,6 +20,7 @@ define([
   moment,
   _,
   _string,
+  NumbersHelper,
   ReportService,
   SummaryChartView,
   HistoricalTrendChartView,
@@ -83,11 +85,12 @@ define([
 
     render: function() {
       var currentDate = moment();
-      var totalReference = Math.round(this.data.emissions.reference.average);
-      var totalMonitoring = Math.round(this.data.emissions.monitor.average);
+      var totalReference = NumbersHelper.round(this.data.emissions.reference.average, 6);
+      var totalMonitoring = NumbersHelper.round(this.data.emissions.monitor.average, 6);
       var increase = Math.round(((totalMonitoring - totalReference) / totalReference) * 100);
       var increaseDisplay = Math.abs(increase);
       var hasIncreased = increase > -1;
+      var hasProvinces = this.data.provinces.emissions.top_five.length > 0;
       var factorAbovegroundBiomass = Math.round(this.data.emission_factors.aboveground);
       var factorBelowgroundBiomass = Math.round(this.data.emission_factors.belowground);
       var factorTotalEmission = Math.round(this.data.emission_factors.total);
@@ -108,6 +111,7 @@ define([
         increase: increase,
         increaseDisplay: increaseDisplay,
         hasIncreased: hasIncreased,
+        hasProvinces: hasProvinces,
         factorAbovegroundBiomass: factorAbovegroundBiomass,
         factorBelowgroundBiomass: factorBelowgroundBiomass ? factorBelowgroundBiomass : '',
         factorTotalEmission: factorTotalEmission,

--- a/app/assets/javascripts/countries/views/report/HistoricalTrendChartView.js
+++ b/app/assets/javascripts/countries/views/report/HistoricalTrendChartView.js
@@ -149,10 +149,10 @@ define([
       for (var indicator in this.data) {
         var current = this.data[indicator];
         if (current && current.values) {
-          current.total = Math.round(current.total);
+          current.total = NumbersHelper.round(current.total, 6);
           current.values.forEach(function(data) {
             if (data) {
-              data.value = Math.round(data.value);
+              data.value = NumbersHelper.round(data.value, 6);
               data.type = indicator;
               this.chartData.push(data);
             }
@@ -401,7 +401,7 @@ define([
       lossGroup.append('text')
         .attr('class', 'value')
         .text(function(d) {
-          return NumbersHelper.addNumberDecimals(Math.round(d.value));
+          return NumbersHelper.addNumberDecimals(NumbersHelper.round(d.value, 6));
         })
         .attr('dx', function() {
           return lossLabelWidth - this.defaults.paddingXAxisLabels

--- a/app/assets/javascripts/countries/views/report/HistoricalTrendChartView.js
+++ b/app/assets/javascripts/countries/views/report/HistoricalTrendChartView.js
@@ -627,7 +627,7 @@ define([
       contentGroup.append('text')
         .attr('class', 'value')
         .text(function(d) {
-          return NumbersHelper.addNumberDecimals(Math.round(d.value));
+          return NumbersHelper.addNumberDecimals(NumbersHelper.round(d.value, 6));
         })
         .attr('dx', function() {
           return averageLabelWidth - this.defaults.paddingXAxisLabels

--- a/app/assets/javascripts/countries/views/report/SummaryChartView.js
+++ b/app/assets/javascripts/countries/views/report/SummaryChartView.js
@@ -3,12 +3,14 @@ define([
   'underscore',
   'd3',
   'moment',
+  'helpers/NumbersHelper',
   'text!countries/templates/report/summary-chart.handlebars'
 ], function(
   Backbone,
   _,
   d3,
   moment,
+  NumbersHelper,
   tpl
 ) {
 
@@ -61,8 +63,8 @@ define([
     },
 
     _start: function() {
-      var referenceAvg = Math.round(this.referenceData.average);
-      var monitoringAvg = Math.round(this.monitoringData.average);
+      var referenceAvg = NumbersHelper.round(this.referenceData.average, 6);
+      var monitoringAvg = NumbersHelper.round(this.monitoringData.average, 6);
       var increase = Math.round(((monitoringAvg - referenceAvg) / referenceAvg) * 100);
       var hasIncreased = increase > -1;
 

--- a/app/assets/javascripts/helpers/NumbersHelper.js
+++ b/app/assets/javascripts/helpers/NumbersHelper.js
@@ -13,7 +13,11 @@ define([
       var formattedNumber = '-';
 
       if (number) {
-        formattedNumber = number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        if (number > 1) {
+          formattedNumber = number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+        } else {
+          formattedNumber = number;
+        }
       }
       return formattedNumber;
     },
@@ -30,6 +34,18 @@ define([
 
     padNumberToTwo: function(number) {
       return ("0" + number.toString()).slice(-2);
+    },
+
+    round: function(number, decimals) {
+      var result = number;
+      if (number) {
+        var toDecimals = decimals || 2;
+        result = parseFloat((number * 1).toFixed(toDecimals));
+        if (result > 1) {
+          result = Math.round(result);
+        }
+      }
+      return result;
     }
   };
 

--- a/app/assets/stylesheets/modules/countries/report/_summary-chart.scss
+++ b/app/assets/stylesheets/modules/countries/report/_summary-chart.scss
@@ -84,7 +84,8 @@
     margin-top: 30px;
 
     .content {
-      width: 370px;
+      min-width: 370px;
+      max-width: 408px;
       margin: 0 auto;
 
       .list {


### PR DESCRIPTION
- Hide some texts when there aren't any provinces available.
- Show smaller values with a custom round helper.

![screen shot 2017-03-14 at 14 53 28](https://cloud.githubusercontent.com/assets/4885740/23904050/d5bb3702-08c6-11e7-97ec-e6ae2d08abc9.png)

![screen shot 2017-03-14 at 14 59 12](https://cloud.githubusercontent.com/assets/4885740/23904058/d9f3c4a6-08c6-11e7-9179-ac5f661c118b.png)
