### PR TITLE
Changed Land use polygon transparency

### DIFF
--- a/app/assets/javascripts/map/cartocss/style.cartocss
+++ b/app/assets/javascripts/map/cartocss/style.cartocss
@@ -58,6 +58,7 @@
 
   [layer='gfw_logging'] {
     polygon-fill: #fecc5c;
+    polygon-opacity: 0.1;
     line-color: #B38E3B;
     line-clip: false;
     polygon-clip: false;
@@ -152,6 +153,7 @@
 
   [layer='gfw_mining'] {
     polygon-fill: #fd8d3c;
+    polygon-opacity: 0.1;
     line-color: #fd8d3c;
     line-clip: false;
     polygon-clip: false;
@@ -215,6 +217,7 @@
   }
   [layer='gfw_oil_palm'] {
     polygon-fill: #ee9587;
+    polygon-opacity: 0.1;
     line-color: #ee9587;
     line-clip: false;
     polygon-clip: false;
@@ -290,6 +293,7 @@
 
   [layer='gfw_wood_fiber'] {
     polygon-fill: #e6adb9;
+    polygon-opacity: 0.1;
     line-color: #e6adb9;
     line-clip: false;
     polygon-clip: false;
@@ -503,9 +507,8 @@
   }
   [layer='wdpa_protected_areas'] {
     polygon-fill: #2167AB;
-    polygon-opacity: 0.5;
+    polygon-opacity: 0.1;
     line-color: #2167AB;
-    line-width: 1;
     line-opacity: 1;
   }
 


### PR DESCRIPTION
*Increased Land Use polygon transparency to 90%
* Reduced line width of protected areas polygons

These changes were made in response to a basecamp issue from the clients.

### Before
![screen shot 2017-05-17 at 09 58 46](https://cloud.githubusercontent.com/assets/6503031/26146104/43b64ddc-3aef-11e7-8bfc-fe80cf7269f0.png)


### After
![screen shot 2017-05-17 at 11 03 34](https://cloud.githubusercontent.com/assets/6503031/26146513/b9d712c0-3af0-11e7-972d-cd3a1660fac7.png)

