### PR TITLE
Removed geojson of tropical focus

### DIFF
--- a/app/assets/javascripts/map/views/MapView.js
+++ b/app/assets/javascripts/map/views/MapView.js
@@ -462,7 +462,9 @@ define([
       for (var i = 1999; i < 2013; i++) {
         this.map.mapTypes.set('landsat{0}'.format(i), landsatMaptype([i]));
       }
-      this.map.data.addGeoJson(JSON.parse(tropicsOverlay));
+      // The below line greys out areas outside of the tropics, using a
+      // geojson in map/geojson_overlays/tropics.json. Deactivated 29th May 2017
+      //this.map.data.addGeoJson(JSON.parse(tropicsOverlay));
     },
 
     /**

--- a/app/assets/javascripts/map/views/MapView.js
+++ b/app/assets/javascripts/map/views/MapView.js
@@ -18,10 +18,9 @@ define([
   'map/views/maptypes/basemapStyles',
   'map/views/GeoStylingView',
   'map/helpers/layersHelper',
-  'text!map/geojson_overlays/tropics.json'
 ], function(Backbone, _, enquire, mps, Presenter, grayscaleMaptype, treeheightMaptype,
   darkMaptype, positronMaptype, landsatMaptype, BasemapStyles, GeoStylingView,
-  layersHelper, tropicsOverlay) {
+  layersHelper) {
 
   'use strict';
 
@@ -462,9 +461,6 @@ define([
       for (var i = 1999; i < 2013; i++) {
         this.map.mapTypes.set('landsat{0}'.format(i), landsatMaptype([i]));
       }
-      // The below line greys out areas outside of the tropics, using a
-      // geojson in map/geojson_overlays/tropics.json. Deactivated 29th May 2017
-      //this.map.data.addGeoJson(JSON.parse(tropicsOverlay));
     },
 
     /**


### PR DESCRIPTION
* Removed application of shade (from tropics.json) to high-latitudes

[Basecamp issue](https://basecamp.com/1756858/projects/9386799/todos/310148667#comment_532068100)

As seen below, there is no longer a shade band over high-latitudes. This is because the new data layers which will be added will be global in extent.

![screen shot 2017-05-29 at 10 06 40](https://cloud.githubusercontent.com/assets/6503031/26543067/c167b10a-445c-11e7-84a8-e61a1b16b998.png)
