### PR TITLE
Fixes bug with province calculations outside plantations.

### DIFF
--- a/app/models/country_report.rb
+++ b/app/models/country_report.rb
@@ -177,9 +177,7 @@ class CountryReport
         excluded_vals = data.select do |t|
           t["boundary"] == INSIDE_PLANTATIONS_BOUNDARY &&
             t["indicator_id"] == indicator &&
-            t["sub_nat_id"] == sub_nat_id &&
-            t["year"] >= start_year &&
-            t["year"] <= end_year
+            t["sub_nat_id"] == sub_nat_id
         end
         vals.each do |t|
           exclude = excluded_vals.select{|p| p["year"] == t["year"]}.first


### PR DESCRIPTION
So just realised that when we made this change: https://github.com/Vizzuality/gfw-climate/commit/c5f343192e4d65f459654377d11292b30adb0716 , and updated the method get_province_vals_for we forgot to update the whole method, and we missed this bug that only happens in some countries due to the selections... Now fixed.