### PR TITLE
Sort data by year to avoid it coming randomly

### DIFF
--- a/app/models/country_report.rb
+++ b/app/models/country_report.rb
@@ -49,6 +49,7 @@ class CountryReport
     url = base_path
     url += select_query
     url += where_clause
+    url += ' ORDER BY year'
 
     puts url
 


### PR DESCRIPTION
There's something weird happening on the monitoring report, with the years mixed, see screenshot:

<img width="862" alt="screen shot 2017-08-16 at 12 17 53" src="https://user-images.githubusercontent.com/10764/29360919-05b8c854-827d-11e7-8d1b-87e4d2926b2e.png">

http://climate.globalforestwatch.org/countries/IDN/report?reference_start_year=2001&reference_end_year=2007&monitor_start_year=2008&monitor_end_year=2015&thresh=30&below=false&primary_forest=true&exclude_plantations=true&co2=true&iso=IDN

This should fix it. =)