### PR TITLE
Fix: header overlay on mobile

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,6 +1,5 @@
 // HEADER
 .layout-header {
-  position: absolute;
   width: 100%;
   height: auto;
   z-index: 1000;


### PR DESCRIPTION
There is an issue with the new header on mobile views. Due to the fixed position of the header (without any height) this causes the page below to be hidden by the same amount of the header from view. This occurs in all views except the map. Simple fix, removing the absolute positioning from the layout.