### PR TITLE
updated WHRC carbon layer

### DIFF
--- a/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
+++ b/app/assets/javascripts/map/views/layers/CarbonStocksLayer.js
@@ -18,7 +18,7 @@ define(
         threshold: 30,
         dataMaxZoom: 12,
         urlTemplate:
-          'http://storage.googleapis.com/earthenginepartners-wri/whrc-hansen-carbon-{threshold}-{z}{/x}{/y}.png',
+          'https://storage.googleapis.com/wri-public/biomass/2017/v1/{threshold}/{z}/{x}/{y}.png',
         uncertainty: 127,
         minrange: 0,
         maxrange: 255


### PR DESCRIPTION
Updated the aboveground live woody biomass density layer with Brookie's new tile source.

![screen shot 2018-08-23 at 12 57 50](https://user-images.githubusercontent.com/6503031/44521733-58eced80-a6d4-11e8-979c-b2949c736eb1.png)
